### PR TITLE
Refactor: Rename groups to tags

### DIFF
--- a/ATTM2X/ATTM2X.Tests/M2XClientTests.cs
+++ b/ATTM2X/ATTM2X.Tests/M2XClientTests.cs
@@ -23,7 +23,7 @@ namespace ATTM2X.Tests
 		{
 			// device
 
-			response = m2x.DeviceGroups().Result;
+			response = m2x.DeviceTags().Result;
 			Assert.IsNotNull(m2x.LastResponse);
 			Assert.AreEqual(HttpStatusCode.OK, response.Status, response.Raw);
 			Assert.IsTrue(response.Success);

--- a/ATTM2X/ATTM2X/Classes/DeviceParams.cs
+++ b/ATTM2X/ATTM2X/Classes/DeviceParams.cs
@@ -16,7 +16,7 @@ namespace ATTM2X.Classes
 		public string visibility;
 		public string status;
 		public string serial;
-		public string[] groups;
+		public string[] tags;
 		public string url;
 		public LocationDetails location;
 		public string created;
@@ -47,7 +47,7 @@ namespace ATTM2X.Classes
 		[DataMember]
 		public string visibility;
 		[DataMember(EmitDefaultValue = false)]
-		public string groups;
+		public string tags;
 	}
 
 	[DataContract]

--- a/ATTM2X/ATTM2X/M2XClient.cs
+++ b/ATTM2X/ATTM2X/M2XClient.cs
@@ -117,24 +117,24 @@ namespace ATTM2X
 		}
 
 		/// <summary>
-		/// List Device Groups
-		/// Retrieve the list of device groups for the authenticated user.
+		/// List Device Tags
+		/// Retrieve the list of device tags for the authenticated user.
 		///
-		/// https://m2x.att.com/developer/documentation/v2/device#List-Device-Groups
+		/// https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags
 		/// </summary>
-		public Task<M2XResponse> DeviceGroups(object parms = null)
+		public Task<M2XResponse> DeviceTags(object parms = null)
 		{
-			return MakeRequest(M2XDevice.UrlPath + "/groups", M2XClientMethod.GET, parms);
+			return MakeRequest(M2XDevice.UrlPath + "/tags", M2XClientMethod.GET, parms);
 		}
 		/// <summary>
-		/// List Device Groups
-		/// Retrieve the list of device groups for the authenticated user.
+		/// List Device Tags
+		/// Retrieve the list of device tags for the authenticated user.
 		///
-		/// https://m2x.att.com/developer/documentation/v2/device#List-Device-Groups
+		/// https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags
 		/// </summary>
-		public Task<M2XResponse> DeviceGroups(CancellationToken cancellationToken, object parms = null)
+		public Task<M2XResponse> DeviceTags(CancellationToken cancellationToken, object parms = null)
 		{
-			return MakeRequest(cancellationToken, M2XDevice.UrlPath + "/groups", M2XClientMethod.GET, parms);
+			return MakeRequest(cancellationToken, M2XDevice.UrlPath + "/tags", M2XClientMethod.GET, parms);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The groups concept has been deprecated in favor of [tags](https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags).

Add the necessary changes to this library to reflect that change.